### PR TITLE
Fixed some bugs

### DIFF
--- a/montepython/analyze.py
+++ b/montepython/analyze.py
@@ -788,8 +788,8 @@ def minimum_credible_intervals(info):
     bounds = np.zeros((len(levels), 2))
     j = 0
     delta = bincenters[1]-bincenters[0]
-    left_edge = np.max(histogram[0] - 0.5*(histogram[1]-histogram[0]), 0.)
-    right_edge = np.max(histogram[-1] + 0.5*(histogram[-1]-histogram[-2]), 0.)
+    left_edge = np.max(histogram[0] - 0.5*(histogram[1]-histogram[0]), 0)
+    right_edge = np.max(histogram[-1] + 0.5*(histogram[-1]-histogram[-2]), 0)
     failed = False
     for level in levels:
         norm = float(

--- a/montepython/analyze.py
+++ b/montepython/analyze.py
@@ -672,6 +672,23 @@ def compute_posterior(information_instances):
                                 "'%s-%s' 2d-plot" % (
                                     info.plotted_parameters[info.native_index],
                                     info.plotted_parameters[info.native_second_index]))
+                        except ValueError as e:
+                            if str(e) == "Contour levels must be increasing":
+                                warnings.warn(
+                                    "The routine could not find the contour of the " +
+                                    "'%s-%s' 2d-plot. \n " % (
+                                        info.plotted_parameters[info.native_index],
+                                        info.plotted_parameters[info.native_second_index]) +
+                                    'The error is: "Contour levels must be increasing"' +
+                                    " but " + str(ctr_level(info.n, info.levels[:2])) +
+                                    " were found. This may happen when most" +
+                                    " points fall in the same bin.")
+                            else:
+                                warnings.warn(
+                                    "The routine could not find the contour of the " +
+                                    "'%s-%s' 2d-plot" % (
+                                        info.plotted_parameters[info.native_index],
+                                        info.plotted_parameters[info.native_second_index]))
 
                         ax2dsub.set_xticks(info.ticks[info.native_second_index])
                         if index == len(plotted_parameters)-1:


### PR DESCRIPTION
I've fixed two bugs. 

1. fixed TypeError np.max for numpy 1.12

The numpy's max method signature is:
np.max(a, axis=None, out=None, keepdims=<class numpy._globals._NoValue at 0x7f9e511bebb0>)
where 
axis : None or int or tuple of ints, optional

2.  Fixed ValueError: "Contour levels must be increasing" found when computing the 2d plots. It was caused presumably by the promotion from Warning to ValueError at some point in matplotlib development, because there were an except handling Warnings. I've added another except that controls ValueErrors and, in case it is the mentioned one, prints a more informative message.

