### PR TITLE
Planck compressed likelihood + error_log per chain

### DIFF
--- a/montepython/data.py
+++ b/montepython/data.py
@@ -1006,7 +1006,7 @@ class Parameter(dict):
             raise io_mp.ParameterError("You chose scale 0 to param {}. Correct\
                                        it.".format(key))
 
-        self['role'] = array[-1]
+        self['role'] = array[5]
         self['tex_name'] = io_mp.get_tex_name(key)
         if array[3] == 0:
             self['status'] = 'fixed'

--- a/montepython/initialise.py
+++ b/montepython/initialise.py
@@ -84,6 +84,7 @@ def initialise(custom_command=''):
             io_mp.create_output_files(command_line, data)
         # NS: Creating the NS subfolder and the MultiNest arguments
         elif command_line.method == 'NS':
+            io_mp.create_output_files(command_line, data, only_error=True)
             from nested_sampling import initialise as initialise_ns
             initialise_ns(cosmo, data, command_line)
 

--- a/montepython/io_mp.py
+++ b/montepython/io_mp.py
@@ -255,12 +255,12 @@ def print_error(error_msg, data):
 
     if "Isnan v_X" in error_msg:
       err_code = 10
-      
+
     if 'Isnan v_X' in error_msg:
       err_code = 10
     if 'early_smg' and 'adiabatic' in error_msg:
       err_code = 11
-    
+
     out = data.err
     for elem in data.get_mcmc_parameters(['varying']):
       out.write('%.6e\t' %
@@ -286,7 +286,7 @@ def refresh_file(data):
     data.err = open(data.err_name, 'a')
 
 
-def create_output_files(command_line, data):
+def create_output_files(command_line, data, only_error=False):
     """
     Automatically create a new name for the chain.
 
@@ -302,6 +302,14 @@ def create_output_files(command_line, data):
         changing things here.
 
     """
+
+    if only_error:
+        #open/create error file
+        data.err_name = os.path.join(command_line.folder,"error_log.txt")
+        data.err = open(data.err_name,'a')
+        print 'Creating error file %s\n' % data.err_name
+        return
+
     if command_line.restart is None:
         number = command_line.N
     else:
@@ -340,10 +348,6 @@ def create_output_files(command_line, data):
         for line in open(command_line.restart, 'r'):
             data.out.write(line)
 
-    #open/create error file
-    data.err_name = os.path.join(command_line.folder,"error_log.txt")
-    data.err = open(data.err_name,'a')
-    print 'Creating error file %s\n' % data.err_name
 
 
 

--- a/montepython/likelihoods/Planck_compressed/Planck_compressed.data
+++ b/montepython/likelihoods/Planck_compressed/Planck_compressed.data
@@ -8,8 +8,6 @@
 
 # Covariance matrix_ij = sigma_i sigma_j Correlation_matrix_ij
 
-#Planck_compressed.inverse_correlation_matrix = np.linalg.inv([[1., 0.54, -0.63, -0.86], [0.54, 1., -0.43, -0.48],  [-0.63, -0.43, 1., 0.58], [-0.86, -0.48, 0.58, 1.]]) 
-
 Planck_compressed.inverse_correlation_matrix = [[ 4.51266537, -0.59697118, 0.75581806,  3.15597158], [-0.59697118,  1.43957767,  0.21084593,  0.05531143], [ 0.75581806,  0.21084593,  1.70453221, -0.2374191 ], [ 3.15597158, 0.05531143, -0.2374191 ,  3.87838813]]
 
                       # mean, std. dev. (sigma)
@@ -18,7 +16,8 @@ Planck_compressed.inverse_correlation_matrix = [[ 4.51266537, -0.59697118, 0.755
 #Planck_compressed.omega_b = [0.02228, 0.00023]
 #Planck_compressed.n_s = [0.9660, 0.0061]
 
-#Planck_compressed.planck_values = np.array([[1.7488, 0.0074], [301.76, 0.14], [0.02228, 0.00023], [0.9660, 0.0061]])
-Planck_compressed.planck_values = [[1.7488, 0.0074], [301.76, 0.14], [0.02228, 0.00023], [0.9660, 0.0061]]
+#Planck_compressed.planck_values = [[1.7488, 0.0074], [301.76, 0.14], [0.02228, 0.00023], [0.9660, 0.0061]]
 
+Planck_compressed.planck_values_mean = [1.7488, 301.76, 0.02228, 0.9660]
+Planck_compressed.planck_values_sigma = [0.0074, 0.14, 0.00023, 0.0061]
                

--- a/montepython/likelihoods/Planck_compressed/Planck_compressed.data
+++ b/montepython/likelihoods/Planck_compressed/Planck_compressed.data
@@ -1,0 +1,24 @@
+# Covriance matrix of the compressed likelihood for Planck TT + lowP
+# (arXiv:1502.01590v2, Table 4)
+                                       # R, l_A, omega_b, n_s
+#Planck_compressed.correlation_matrix = [[1., 0.54, -0.63, -0.86],\ # R
+#                                        [0.54, 1., -0.43, -0.48],\ # l_A  
+#                                        [-0.63, -0.43, 1., 0.58],\ # omega_b
+#                                        [-0.86, -0.48, 0.58, 1.]] # n_s 
+
+# Covariance matrix_ij = sigma_i sigma_j Correlation_matrix_ij
+
+#Planck_compressed.inverse_correlation_matrix = np.linalg.inv([[1., 0.54, -0.63, -0.86], [0.54, 1., -0.43, -0.48],  [-0.63, -0.43, 1., 0.58], [-0.86, -0.48, 0.58, 1.]]) 
+
+Planck_compressed.inverse_correlation_matrix = [[ 4.51266537, -0.59697118, 0.75581806,  3.15597158], [-0.59697118,  1.43957767,  0.21084593,  0.05531143], [ 0.75581806,  0.21084593,  1.70453221, -0.2374191 ], [ 3.15597158, 0.05531143, -0.2374191 ,  3.87838813]]
+
+                      # mean, std. dev. (sigma)
+#Planck_compressed.R = [1.7488, 0.0074]
+#Planck_compressed.l_a = [301.76, 0.14]
+#Planck_compressed.omega_b = [0.02228, 0.00023]
+#Planck_compressed.n_s = [0.9660, 0.0061]
+
+#Planck_compressed.planck_values = np.array([[1.7488, 0.0074], [301.76, 0.14], [0.02228, 0.00023], [0.9660, 0.0061]])
+Planck_compressed.planck_values = [[1.7488, 0.0074], [301.76, 0.14], [0.02228, 0.00023], [0.9660, 0.0061]]
+
+               

--- a/montepython/likelihoods/Planck_compressed/__init__.py
+++ b/montepython/likelihoods/Planck_compressed/__init__.py
@@ -1,8 +1,8 @@
-from montepython.likelihood_class import Likelihood_prior
+from montepython.likelihood_class import Likelihood
 import numpy as np
 
 
-class Planck_compressed(Likelihood_prior):
+class Planck_compressed(Likelihood):
 
     # initialisation of the class is done within the parent Likelihood_prior. For
     # this case, it does not differ, actually, from the __init__ method in

--- a/montepython/likelihoods/Planck_compressed/__init__.py
+++ b/montepython/likelihoods/Planck_compressed/__init__.py
@@ -21,15 +21,14 @@ class Planck_compressed(Likelihood_prior):
         n_s = cosmo.n_s()
 
         values = np.array([R, l_a, omega_b, n_s])
-        planck_values = zip(*self.planck_values)
 
         # loglkl = -1/2 * (x_i - x_mean_i) * 1/sigma_i * corr_mat_ij^-1 *
         #                 1/sigma_j * (x_j - x_mean_j)
 
-        differences_over_sigma = ((values[:][0] - planck_values[0]) /
-                                  planck_values[1])
+        differences_over_sigma = (values - np.array(self.planck_values_mean)) / self.planck_values_sigma
 
         loglkl = -0.5 * np.dot(differences_over_sigma,
                                np.dot(self.inverse_correlation_matrix,
                                       differences_over_sigma))
+
         return loglkl

--- a/montepython/likelihoods/Planck_compressed/__init__.py
+++ b/montepython/likelihoods/Planck_compressed/__init__.py
@@ -11,7 +11,8 @@ class Planck_compressed(Likelihood_prior):
     def loglkl(self, cosmo, data):
 
         z_star = cosmo.z_optical_depth_unity()  # z at which the optical depth is unity
-        D_A_star = cosmo.angular_distance(z_star)
+        # comoving angular diameter distance
+        D_A_star = cosmo.angular_distance(z_star) * (z_star + 1)
         rs_star = cosmo.rs_at_z(z_star)
 
         R = np.sqrt(cosmo.Omega_m()) * cosmo.Hubble(0) * D_A_star

--- a/montepython/likelihoods/Planck_compressed/__init__.py
+++ b/montepython/likelihoods/Planck_compressed/__init__.py
@@ -1,0 +1,34 @@
+from montepython.likelihood_class import Likelihood_prior
+import numpy as np
+
+
+class Planck_compressed(Likelihood_prior):
+
+    # initialisation of the class is done within the parent Likelihood_prior. For
+    # this case, it does not differ, actually, from the __init__ method in
+    # Likelihood class.
+
+    def loglkl(self, cosmo, data):
+
+        z_star = cosmo.z_optical_depth_unity()  # z at which the optical depth is unity
+        D_A_star = cosmo.angular_distance(z_star)
+        rs_star = cosmo.rs_at_z(z_star)
+
+        R = np.sqrt(cosmo.Omega_m()) * cosmo.Hubble(0) * D_A_star
+        l_a = np.pi * D_A_star / rs_star
+        omega_b = cosmo.omega_b()
+        n_s = cosmo.n_s()
+
+        values = np.array([R, l_a, omega_b, n_s])
+        planck_values = zip(*self.planck_values)
+
+        # loglkl = -1/2 * (x_i - x_mean_i) * 1/sigma_i * corr_mat_ij^-1 *
+        #                 1/sigma_j * (x_j - x_mean_j)
+
+        differences_over_sigma = ((values[:][0] - planck_values[0]) /
+                                  planck_values[1])
+
+        loglkl = -0.5 * np.dot(differences_over_sigma,
+                               np.dot(self.inverse_correlation_matrix,
+                                      differences_over_sigma))
+        return loglkl

--- a/montepython/likelihoods/Planck_compressed/__init__.py
+++ b/montepython/likelihoods/Planck_compressed/__init__.py
@@ -20,12 +20,16 @@ class Planck_compressed(Likelihood):
         omega_b = cosmo.omega_b()
         n_s = cosmo.n_s()
 
-        values = np.array([R, l_a, omega_b, n_s])
+        # Using self in order to be accesible by data_mp_likelihoods.py
+        # work-in-class module.
+        # https://github.com/miguelzuma/work-in-class &&
+        # https://github.com/ardok-m/work-in-class &&
+        self.values = np.array([R, l_a, omega_b, n_s])
 
         # loglkl = -1/2 * (x_i - x_mean_i) * 1/sigma_i * corr_mat_ij^-1 *
         #                 1/sigma_j * (x_j - x_mean_j)
 
-        differences_over_sigma = (values - np.array(self.planck_values_mean)) / self.planck_values_sigma
+        differences_over_sigma = (self.values - np.array(self.planck_values_mean)) / self.planck_values_sigma
 
         loglkl = -0.5 * np.dot(differences_over_sigma,
                                np.dot(self.inverse_correlation_matrix,


### PR DESCRIPTION
New features:

- Added Planck compressed likelihood (Table 4 from arXiv:1502.01590) (Fully compatible with work-in-class)

- one error_log.txt file created per chain.

- Added triangular prior option

- Fixed interpretation of 7th item in data.parameters[...]. It allows choosing different priors but was badly implemented and not taken into account.

- Fixed not instantiation of data.err with Nested Sampling.