### PR TITLE
Fix Planck compressed likelihood and Cosmo Hammer derived parameters

### DIFF
--- a/montepython/cosmo_hammer.py
+++ b/montepython/cosmo_hammer.py
@@ -235,7 +235,7 @@ class DerivedUtil(SampleFileUtil):
 
 def store_cosmo_derived(ctx):
     """
-    Store derived parameters. Copied from sampler.compute_lkl
+    Store derived parameters. Based on sampler.compute_lkl
     """
     from classy import CosmoSevereError
 
@@ -246,8 +246,6 @@ def store_cosmo_derived(ctx):
         try:
             derived = cosmo.get_current_derived_parameters(
                 data.get_mcmc_parameters(['derived']))
-            for name, value in derived.iteritems():
-                data.mcmc_parameters[name]['current'] = value
         except AttributeError:
             # This happens if the classy wrapper is still using the old
             # convention, expecting data as the input parameter
@@ -255,6 +253,9 @@ def store_cosmo_derived(ctx):
         except CosmoSevereError:
             raise io_mp.CosmologicalModuleError(
                 "Could not write the current derived parameters")
-    for elem in data.get_mcmc_parameters(['derived']):
-        data.mcmc_parameters[elem]['current'] /= \
-            data.mcmc_parameters[elem]['scale']
+
+    # If we want the derived parameters stored rescaled
+    # derived_scaled = {elem: value/data.mcmc_parameters[elem]['scale'] for elem, value in derived.iteritems()}
+    # ctx.add('key_data', derived_scaled)
+
+    ctx.add('key_data', derived)

--- a/montepython/cosmo_hammer.py
+++ b/montepython/cosmo_hammer.py
@@ -254,8 +254,8 @@ def store_cosmo_derived(ctx):
             raise io_mp.CosmologicalModuleError(
                 "Could not write the current derived parameters")
 
-    # If we want the derived parameters stored rescaled
-    # derived_scaled = {elem: value/data.mcmc_parameters[elem]['scale'] for elem, value in derived.iteritems()}
-    # ctx.add('key_data', derived_scaled)
+        ctx.add('key_data', derived)
 
-    ctx.add('key_data', derived)
+        # If we want the derived parameters stored rescaled
+        # derived_scaled = {elem: value/data.mcmc_parameters[elem]['scale'] for elem, value in derived.iteritems()}
+        # ctx.add('key_data', derived_scaled)

--- a/montepython/cosmo_hammer.py
+++ b/montepython/cosmo_hammer.py
@@ -219,7 +219,8 @@ class DerivedUtil(SampleFileUtil):
         derived_not_computed = [np.NaN] * len(CH_derived_names)
 
         derived = np.array(
-            [[a for a in elem.itervalues()] if elem else derived_not_computed for elem in data])
+            #[[a for a in elem.itervalues()] if elem else derived_not_computed for elem in data])
+            [[elem[key] for key in sorted(elem.iterkeys())] if elem else derived_not_computed for elem in data])
         final = np.concatenate((pos, derived), axis=1)
 
         posFile.write("\n".join(

--- a/montepython/likelihoods/Planck_compressed/__init__.py
+++ b/montepython/likelihoods/Planck_compressed/__init__.py
@@ -10,10 +10,14 @@ class Planck_compressed(Likelihood):
 
     def loglkl(self, cosmo, data):
 
-        z_star = cosmo.z_optical_depth_unity()  # z at which the optical depth is unity
+        derived_params = cosmo.get_current_derived_parameters(['z_rec', 'rs_rec'])
+
+        #z_star = cosmo.z_optical_depth_unity()  # z at which the optical depth is unity
+        z_star = derived_params['z_rec']  # z at which the optical depth is unity
         # comoving angular diameter distance
         D_A_star = cosmo.angular_distance(z_star) * (z_star + 1)
-        rs_star = cosmo.rs_at_z(z_star)
+        #rs_star = cosmo.rs_at_z(z_star)
+        rs_star = derived_params['rs_rec']
 
         R = np.sqrt(cosmo.Omega_m()) * cosmo.Hubble(0) * D_A_star
         l_a = np.pi * D_A_star / rs_star


### PR DESCRIPTION
The Planck compressed likelihood used an unacurate variable. Using the default one gives correct results.
`cosmo_hammer.py` module did not write correctly the derived parameters: they were mixed along different steps. This update fixes it.